### PR TITLE
Improve screenshot stability

### DIFF
--- a/dnsrazzle/BrowserUtil.py
+++ b/dnsrazzle/BrowserUtil.py
@@ -36,7 +36,7 @@ __twitter__ = '@securityshrimp'
 __email__ = 'securityshrimp@proton.me'
 
 from .IOUtil import print_debug, print_error
-from selenium.common.exceptions import WebDriverException
+from selenium.common.exceptions import WebDriverException, TimeoutException
 from fake_useragent import UserAgent
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
@@ -44,6 +44,7 @@ from selenium.webdriver.firefox.service import Service as FirefoxService
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
+from selenium.webdriver.support.ui import WebDriverWait
 import selenium
 import tempfile
 import os
@@ -154,6 +155,33 @@ def screenshot_domain(driver, domain, out_dir, retries=1):
         try:
             driver.set_page_load_timeout(15)
             driver.get(url)
+            WebDriverWait(driver, 10).until(
+                lambda d: d.execute_script("return document.readyState") == "complete"
+            )
+
+            # Wait a bit longer for images or async content to finish loading
+            try:
+                WebDriverWait(driver, 5).until(
+                    lambda d: d.execute_script(
+                        "return Array.from(document.images).every(img => img.complete)"
+                    )
+                )
+            except TimeoutException:
+                pass
+
+            try:
+                # Resize the browser to match the full page height/width
+                page_height = driver.execute_script(
+                    "return Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);"
+                )
+                page_width = driver.execute_script(
+                    "return Math.max(document.body.scrollWidth, document.documentElement.scrollWidth);"
+                )
+                driver.set_window_size(page_width, page_height)
+                time.sleep(1)
+            except WebDriverException:
+                pass
+
             driver.get_screenshot_as_file(ss_path)
             return True
 


### PR DESCRIPTION
## Summary
- wait up to five seconds for images to finish loading

## Testing
- `python3 -m py_compile dnsrazzle/BrowserUtil.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684899e81d0483318fc9f16850917034