### PR TITLE
Improve screenshot timing

### DIFF
--- a/DNSrazzle.py
+++ b/DNSrazzle.py
@@ -83,6 +83,8 @@ def main():
     parser.add_argument('-u', '--useragent', type=str, metavar='STRING', default='Mozilla/5.0 dnsrazzle/%s' % __version__,
                         help='User-Agent STRING to send with HTTP requests. Default is Mozilla/5.0 dnsrazzle/%s)' % __version__)
     parser.add_argument('--debug', dest='debug', action='store_true', default=False, help='Print debug messages')
+    parser.add_argument('--screenshot-delay', dest='screenshot_delay', type=int, default=2,
+                        help='Seconds to wait after page load before taking a screenshot')
     arguments = parser.parse_args()
 
     out_dir = arguments.out_dir
@@ -93,6 +95,7 @@ def main():
     nameserver = arguments.nameserver
     nmap = arguments.nmap
     recon = arguments.recon
+    screenshot_delay = arguments.screenshot_delay
     email = arguments.email
     no_screenshot = arguments.no_screenshot
     driver = None
@@ -155,9 +158,10 @@ def main():
     razzles: list[DnsRazzle] = []
     bar = Bar(f'Generating possible domain name impersonations…', max=len(domain_raw_list))
     for entry in domain_raw_list:
-        razzle = DnsRazzle(domain=str(entry), out_dir=out_dir, tld=tld, dictionary=dictionary, file=arguments.file,
-                useragent=useragent, debug=debug, threads=threads, nmap=nmap, recon=recon, driver=driver,
-                nameserver=nameserver)
+        razzle = DnsRazzle(domain=str(entry), out_dir=out_dir, tld=tld, dictionary=dictionary,
+                file=arguments.file, useragent=useragent, debug=debug, threads=threads,
+                nmap=nmap, recon=recon, driver=driver, nameserver=nameserver,
+                screenshot_delay=screenshot_delay)
         razzles.append(razzle)
         razzle.generate_fuzzed_domains()
         bar.next()

--- a/dnsrazzle/BrowserUtil.py
+++ b/dnsrazzle/BrowserUtil.py
@@ -132,7 +132,7 @@ def get_webdriver(browser_name):
             shutil.rmtree(temp_profile, ignore_errors=True)
         return None
 
-def screenshot_domain(driver, domain, out_dir, retries=1, width=1920, height=1080):
+def screenshot_domain(driver, domain, out_dir, retries=1, width=1920, height=1080, wait=2):
     """
     Function to take screenshot of supplied domain.
     It retries if a known error occurs (e.g. timeout or renderer issues).
@@ -164,9 +164,9 @@ def screenshot_domain(driver, domain, out_dir, retries=1, width=1920, height=108
 
     for attempt in range(retries + 1):
         try:
-            driver.set_page_load_timeout(15)
+            driver.set_page_load_timeout(30)
             driver.get(url)
-            WebDriverWait(driver, 10).until(
+            WebDriverWait(driver, 20).until(
                 lambda d: d.execute_script("return document.readyState") == "complete"
             )
 
@@ -179,6 +179,10 @@ def screenshot_domain(driver, domain, out_dir, retries=1, width=1920, height=108
                 )
             except TimeoutException:
                 pass
+
+            # Allow additional wait time for dynamic content to finish loading
+            if wait and wait > 0:
+                time.sleep(wait)
 
             try:
                 driver.set_window_size(width, height)

--- a/dnsrazzle/DnsRazzle.py
+++ b/dnsrazzle/DnsRazzle.py
@@ -42,7 +42,9 @@ import queue
 from pathlib import Path
 
 class DnsRazzle():
-    def __init__(self, domain, out_dir, tld, dictionary, file, useragent, debug, threads, nmap, recon, driver, nameserver = '1.1.1.1'):
+    def __init__(self, domain, out_dir, tld, dictionary, file, useragent, debug,
+                 threads, nmap, recon, driver, nameserver='1.1.1.1',
+                 screenshot_delay=2):
         self.domains = []
         self.domain = domain
         self.out_dir = out_dir
@@ -59,6 +61,7 @@ class DnsRazzle():
         self.recon = recon
         self.nameserver = nameserver
         self.driver = driver
+        self.screenshot_delay = screenshot_delay
 
     def generate_fuzzed_domains(self):
         from dnstwist import DomainFuzz
@@ -112,7 +115,10 @@ class DnsRazzle():
             worker.join()
 
     def check_domains(self, progress_callback=None):
-        success = screenshot_domain(driver=self.driver, domain=self.domain, out_dir=self.out_dir + '/screenshots/originals/', width=1920, height=1080)
+        success = screenshot_domain(driver=self.driver, domain=self.domain,
+                                   out_dir=self.out_dir + '/screenshots/originals/',
+                                   width=1920, height=1080,
+                                   wait=self.screenshot_delay)
         # if not success:
         #     # The original domain could not be screenshotted, therefore it is
         #     # impossible to do a comparison with any of its variations.
@@ -123,7 +129,11 @@ class DnsRazzle():
         return True
 
     def check_domain(self, domain_entry, progress_callback=None):
-        success = screenshot_domain(driver=self.driver, domain=domain_entry['domain-name'], out_dir=self.out_dir + '/screenshots/', width=1920, height=1080)
+        success = screenshot_domain(driver=self.driver,
+                                   domain=domain_entry['domain-name'],
+                                   out_dir=self.out_dir + '/screenshots/',
+                                   width=1920, height=1080,
+                                   wait=self.screenshot_delay)
         if success:
             original_png = self.out_dir + '/screenshots/originals/' + self.domain + '.png'
             if Path(original_png).is_file():

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,9 +67,11 @@ DNSRazzle supports single domain names, a comma seperated list of domain names, 
     -t THREADS, --threads THREADS                     | Number of threads to use in permutation checks, reverse lookups, forward lookups, brute force and SRV record enumeration.
     
     --tld FILE                                        | Path to TLD dictionary file.
-  
+
     -u STRING, --useragent STRING                     | User-Agent STRING to send with HTTP requests (default: Mozilla/5.0 dnsrazzle/0.1.0)
-    
+
+    --screenshot-delay INT                            | Seconds to wait after page load before taking screenshot (default: 2)
+
     --debug                                           | Print debug messages
 
 


### PR DESCRIPTION
## Summary
- allow customizing screenshot wait time
- increase page load timeout to handle slow sites
- document new `--screenshot-delay` option

## Testing
- `python -m py_compile DNSrazzle.py dnsrazzle/BrowserUtil.py dnsrazzle/DnsRazzle.py`

------
https://chatgpt.com/codex/tasks/task_e_68499339d9f88331aaec64f0d7b63e50